### PR TITLE
Fix examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ rand = "0.8"
 bevy = { version = "0.7.0", default-features = false, features = [
     "render",
     "bevy_winit",
+    "x11", # github actions runenrs don't have libxkbcommon installed, so can't use wayland
     "filesystem_watcher"
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ bevy_pancam = "0.3"
 bevy_lospec = "0.1.1"
 bevy_asset_loader = "0.10"
 rand = "0.8"
+bevy = { version = "0.7.0", default-features = false, features = ["render", "bevy_winit"] }
 
 [profile.dev]
 opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,11 @@ bevy_pancam = "0.3"
 bevy_lospec = "0.1.1"
 bevy_asset_loader = "0.10"
 rand = "0.8"
-bevy = { version = "0.7.0", default-features = false, features = ["render", "bevy_winit"] }
+bevy = { version = "0.7.0", default-features = false, features = [
+    "render",
+    "bevy_winit",
+    "filesystem_watcher"
+] }
 
 [profile.dev]
 opt-level = 1

--- a/examples/hot_reload.rs
+++ b/examples/hot_reload.rs
@@ -1,0 +1,37 @@
+use bevy::prelude::*;
+use bevy_smud::prelude::*;
+
+fn main() {
+    App::new()
+        .insert_resource(Msaa { samples: 4 })
+        .add_plugins(DefaultPlugins)
+        .add_plugin(SmudPlugin)
+        .add_startup_system(setup)
+        .run();
+}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    asset_server.watch_for_changes().unwrap();
+
+    // When sdfs are loaded from files, hot reloading works as normal
+    // Open up assets/bevy.wgsl and make some changes and see them reflected when you save
+    let bevy = asset_server.load("bevy.wgsl");
+
+    commands.spawn_bundle(ShapeBundle {
+        transform: Transform {
+            scale: Vec3::splat(0.4),
+            ..default()
+        },
+        shape: SmudShape {
+            color: Color::WHITE,
+            sdf: bevy,
+            // You can also specify a custom type of fill
+            // The simple fill is just a simple anti-aliased opaque fill
+            fill: SIMPLE_FILL_HANDLE.typed(),
+            frame: Frame::Quad(295.),
+        },
+        ..default()
+    });
+
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+}


### PR DESCRIPTION
Examples panicked because the `bevy_winit` feature wasn't enabled.

Also add a hot reload example.