### PR TITLE
Update to bevy 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,25 +10,26 @@ repository = "https://github.com/johanhelsing/bevy_smud"
 version = "0.7.0"
 
 [dependencies]
-bevy = { version = "0.12", default-features = false, features = [
+bevy = { version = "0.13", default-features = false, features = [
   "bevy_core_pipeline",
   "bevy_render",
-  "bevy_asset", # needed for handle ids
-]}
-bytemuck = { version = "1.7", features = ["derive"] }
+  "bevy_asset",         # needed for handle ids
+] }
+bytemuck = { version = "1.15.0", features = ["derive"] }
 copyless = "0.1"
-bitflags = "2.4"
-fixedbitset = "0.4"
+bitflags = "2.5"
+fixedbitset = "0.5"
 
 [dev-dependencies]
-bevy = { version = "0.12", default-features = false, features = [
+bevy = { version = "0.13.2", default-features = false, features = [
   "bevy_winit",
-  "x11", # github actions runners don't have libxkbcommon installed, so can't use wayland
+  "x11",            # github actions runners don't have libxkbcommon installed, so can't use wayland
   "file_watcher",
+  "multi-threaded",
 ] }
-bevy_asset_loader = "0.18"
-bevy_lospec = "0.6"
-bevy_pancam = "0.10"
+bevy_asset_loader = "0.20"
+bevy_lospec = "0.7"
+bevy_pancam = "0.11"
 rand = "0.8"
 
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,14 @@ bevy = { version = "0.14", default-features = false, features = [
   "bevy_core_pipeline",
   "bevy_render",
   "bevy_asset",         # needed for handle ids
+  # "bevy_sprite",
+  "multi_threaded",
 ] }
 bytemuck = { version = "1.15.0", features = ["derive"] }
 copyless = "0.1"
 bitflags = "2.5"
 fixedbitset = "0.5"
+uuid = "1.10.0"
 
 [dev-dependencies]
 bevy = { version = "0.14", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ bevy = { version = "0.14", default-features = false, features = [
   "bevy_core_pipeline",
   "bevy_render",
   "bevy_asset",         # needed for handle ids
-  # "bevy_sprite",
   "multi_threaded",
 ] }
 bytemuck = { version = "1.15.0", features = ["derive"] }
@@ -25,6 +24,7 @@ uuid = "1.10.0"
 
 [dev-dependencies]
 bevy = { version = "0.14", default-features = false, features = [
+  "bevy_state",
   "bevy_winit",
   "x11",            # github actions runners don't have libxkbcommon installed, so can't use wayland
   "file_watcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["gamedev", "bevy", "sdf"]
 license = "MIT OR Apache-2.0"
 name = "bevy_smud"
 repository = "https://github.com/johanhelsing/bevy_smud"
-version = "0.7.0"
+version = "0.9.0"
 
 [dependencies]
 bevy = { version = "0.14", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/johanhelsing/bevy_smud"
 version = "0.7.0"
 
 [dependencies]
-bevy = { version = "0.13", default-features = false, features = [
+bevy = { version = "0.14", default-features = false, features = [
   "bevy_core_pipeline",
   "bevy_render",
   "bevy_asset",         # needed for handle ids
@@ -21,15 +21,14 @@ bitflags = "2.5"
 fixedbitset = "0.5"
 
 [dev-dependencies]
-bevy = { version = "0.13.2", default-features = false, features = [
+bevy = { version = "0.14", default-features = false, features = [
   "bevy_winit",
   "x11",            # github actions runners don't have libxkbcommon installed, so can't use wayland
   "file_watcher",
-  "multi-threaded",
 ] }
-bevy_asset_loader = "0.20"
-bevy_lospec = "0.7"
-bevy_pancam = "0.11"
+bevy_asset_loader = "0.21"
+bevy_lospec = "0.8"
+bevy_pancam = "0.12"
 rand = "0.8"
 
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ The `main` branch targets the latest bevy release.
 
 |bevy|bevy_smud|
 |----|---------|
-|0.12|0.7, main|
+|0.14|0.9, main|
+|0.12|0.7      |
 |0.11|0.6      |
 |0.10|0.5      |
 |0.9 |0.4      |

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use bevy::color::palettes::css;
 // The prelude contains the basic things needed to create shapes
 use bevy_smud::prelude::*;
 
@@ -39,7 +40,7 @@ return smud::sd_circle(p_2 - vec2<f32>(20., 0.), 40.);
 
     commands.spawn(ShapeBundle {
         shape: SmudShape {
-            color: Color::TOMATO,
+            color: css::TOMATO.into(),
             sdf: circle,
             // The frame needs to be bigger than the shape we're drawing
             // Since the circle has radius 70, we make the half-size of the quad 80.

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,5 +1,5 @@
-use bevy::prelude::*;
 use bevy::color::palettes::css;
+use bevy::prelude::*;
 // The prelude contains the basic things needed to create shapes
 use bevy_smud::prelude::*;
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -53,7 +53,7 @@ return smud::sd_circle(p_2 - vec2<f32>(20., 0.), 40.);
     commands.spawn(ShapeBundle {
         transform: Transform::from_translation(Vec3::X * 200.),
         shape: SmudShape {
-            color: Color::rgb(0.7, 0.6, 0.4),
+            color: Color::srgb(0.7, 0.6, 0.4),
             sdf: peanut,
             frame: Frame::Quad(80.),
             ..default()

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -9,14 +9,15 @@ use rand::prelude::*;
 
 fn main() {
     App::new()
-        .add_state::<GameState>()
+        .init_state::<GameState>()
         // bevy_smud comes with anti-aliasing built into the standards fills
         // which is more efficient than MSAA, and also works on Linux, wayland
         .insert_resource(Msaa::Off)
         .add_loading_state(
-            LoadingState::new(GameState::Loading).continue_to_state(GameState::Running),
+            LoadingState::new(GameState::Loading)
+                .continue_to_state(GameState::Running)
+                .load_collection::<AssetHandles>(),
         )
-        .add_collection_to_loading_state::<_, AssetHandles>(GameState::Loading)
         .add_plugins((
             DefaultPlugins,
             LogDiagnosticsPlugin::default(),
@@ -43,6 +44,7 @@ struct AssetHandles {
     palette: Handle<bevy_lospec::Palette>,
 }
 
+#[allow(dead_code)]
 #[derive(Component)]
 struct Index(usize);
 

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -1,5 +1,6 @@
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    color::palettes::css,
     prelude::*,
 };
 use bevy_asset_loader::prelude::*;
@@ -75,7 +76,7 @@ fn setup(
                 .filter(|c| *c != &clear_color)
                 .choose(&mut rng)
                 .copied()
-                .unwrap_or(Color::PINK);
+                .unwrap_or(css::PINK.into());
 
             commands.spawn((
                 ShapeBundle {

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -1,6 +1,6 @@
 use bevy::{
-    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     color::palettes::css,
+    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
 };
 use bevy_asset_loader::prelude::*;

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -10,6 +10,14 @@ use rand::prelude::*;
 
 fn main() {
     App::new()
+        .add_plugins((
+            DefaultPlugins,
+            LogDiagnosticsPlugin::default(),
+            FrameTimeDiagnosticsPlugin,
+            SmudPlugin,
+            PanCamPlugin,
+            bevy_lospec::PalettePlugin,
+        ))
         .init_state::<GameState>()
         // bevy_smud comes with anti-aliasing built into the standards fills
         // which is more efficient than MSAA, and also works on Linux, wayland
@@ -19,14 +27,6 @@ fn main() {
                 .continue_to_state(GameState::Running)
                 .load_collection::<AssetHandles>(),
         )
-        .add_plugins((
-            DefaultPlugins,
-            LogDiagnosticsPlugin::default(),
-            FrameTimeDiagnosticsPlugin,
-            SmudPlugin,
-            PanCamPlugin,
-            bevy_lospec::PalettePlugin,
-        ))
         .add_systems(OnEnter(GameState::Running), setup)
         // .add_system_set(SystemSet::on_update(GameState::Running).with_system(update))
         .run();

--- a/examples/bevy.rs
+++ b/examples/bevy.rs
@@ -7,7 +7,7 @@ fn main() {
         // bevy_smud comes with anti-aliasing built into the standards fills
         // which is more efficient than MSAA, and also works on Linux, wayland
         .insert_resource(Msaa::Off)
-        .insert_resource(ClearColor(Color::rgb(0.7, 0.8, 0.7)))
+        .insert_resource(ClearColor(Color::srgb(0.7, 0.8, 0.7)))
         .add_plugins((DefaultPlugins, SmudPlugin, PanCamPlugin))
         .add_systems(Startup, setup)
         .run();
@@ -18,7 +18,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     commands.spawn(ShapeBundle {
         shape: SmudShape {
-            color: Color::rgb(0.36, 0.41, 0.45),
+            color: Color::srgb(0.36, 0.41, 0.45),
             sdf: bevy_shape_shader,
             frame: Frame::Quad(400.),
             ..default()

--- a/examples/bloom.rs
+++ b/examples/bloom.rs
@@ -4,6 +4,7 @@
 //! effects by creating a custom fill.
 
 use bevy::{core_pipeline::bloom::BloomSettings, prelude::*};
+use bevy::color::palettes::css;
 // The prelude contains the basic things needed to create shapes
 use bevy_smud::prelude::*;
 
@@ -27,7 +28,7 @@ fn setup(mut commands: Commands, mut shaders: ResMut<Assets<Shader>>) {
 
     commands.spawn(ShapeBundle {
         shape: SmudShape {
-            color: Color::TOMATO,
+            color: css::TOMATO.into(),
             sdf: circle,
             // The frame needs to be bigger than the shape we're drawing
             // Since the circle has radius 70, we make the half-size of the quad 80.

--- a/examples/bloom.rs
+++ b/examples/bloom.rs
@@ -3,8 +3,8 @@
 //! Note that you could probably achieve cheaper and higher quality bloom-like
 //! effects by creating a custom fill.
 
-use bevy::{core_pipeline::bloom::BloomSettings, prelude::*};
 use bevy::color::palettes::css;
+use bevy::{core_pipeline::bloom::BloomSettings, prelude::*};
 // The prelude contains the basic things needed to create shapes
 use bevy_smud::prelude::*;
 

--- a/examples/custom_fill.rs
+++ b/examples/custom_fill.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use bevy::color::palettes::css;
 use bevy_pancam::*;
 use bevy_smud::{prelude::*, SIMPLE_FILL_HANDLE};
 
@@ -23,7 +24,7 @@ fn setup(
 
     commands.spawn(ShapeBundle {
         shape: SmudShape {
-            color: Color::TEAL,
+            color: css::TEAL.into(),
             sdf: asset_server.load("bevy.wgsl"),
             fill: sin_fill,
             frame: Frame::Quad(295.),
@@ -34,7 +35,7 @@ fn setup(
     commands.spawn(ShapeBundle {
         transform: Transform::from_translation(Vec3::X * 600.),
         shape: SmudShape {
-            color: Color::BLUE,
+            color: css::BLUE.into(),
             sdf: asset_server.load("bevy.wgsl"),
             fill: SIMPLE_FILL_HANDLE,
             frame: Frame::Quad(295.),
@@ -45,7 +46,7 @@ fn setup(
     commands.spawn(ShapeBundle {
         transform: Transform::from_translation(Vec3::X * -600.),
         shape: SmudShape {
-            color: Color::ORANGE,
+            color: css::ORANGE.into(),
             sdf: asset_server.load("bevy.wgsl"),
             fill: shaders.add_fill_body(
                 r"

--- a/examples/custom_fill.rs
+++ b/examples/custom_fill.rs
@@ -1,5 +1,5 @@
-use bevy::prelude::*;
 use bevy::color::palettes::css;
+use bevy::prelude::*;
 use bevy_pancam::*;
 use bevy_smud::{prelude::*, SIMPLE_FILL_HANDLE};
 

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -6,14 +6,15 @@ use rand::prelude::*;
 
 fn main() {
     App::new()
-        .add_state::<GameState>()
+        .init_state::<GameState>()
         // bevy_smud comes with anti-aliasing built into the standards fills
         // which is more efficient than MSAA, and also works on Linux, wayland
         .insert_resource(Msaa::Off)
         .add_loading_state(
-            LoadingState::new(GameState::Loading).continue_to_state(GameState::Running),
+            LoadingState::new(GameState::Loading)
+                .continue_to_state(GameState::Running)
+                .load_collection::<AssetHandles>(),
         )
-        .add_collection_to_loading_state::<_, AssetHandles>(GameState::Loading)
         .add_plugins((
             DefaultPlugins,
             SmudPlugin,
@@ -39,6 +40,7 @@ struct AssetHandles {
     palette: Handle<bevy_lospec::Palette>,
 }
 
+#[allow(dead_code)]
 #[derive(Component)]
 struct Index(usize);
 
@@ -85,7 +87,7 @@ fn setup(
         asset_server.load("gallery/donut.wgsl"),
     ];
 
-    let fills = vec![
+    let fills = [
         // asset_server.load("fills/simple.wgsl"),
         asset_server.load("fills/cubic_falloff.wgsl"),
         asset_server.load("fills/outline.wgsl"),

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -1,5 +1,5 @@
-use bevy::prelude::*;
 use bevy::color::palettes::css;
+use bevy::prelude::*;
 use bevy_asset_loader::prelude::*;
 use bevy_pancam::*;
 use bevy_smud::*;

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use bevy::color::palettes::css;
 use bevy_asset_loader::prelude::*;
 use bevy_pancam::*;
 use bevy_smud::*;
@@ -6,15 +7,8 @@ use rand::prelude::*;
 
 fn main() {
     App::new()
-        .init_state::<GameState>()
         // bevy_smud comes with anti-aliasing built into the standards fills
         // which is more efficient than MSAA, and also works on Linux, wayland
-        .insert_resource(Msaa::Off)
-        .add_loading_state(
-            LoadingState::new(GameState::Loading)
-                .continue_to_state(GameState::Running)
-                .load_collection::<AssetHandles>(),
-        )
         .add_plugins((
             DefaultPlugins,
             SmudPlugin,
@@ -23,6 +17,13 @@ fn main() {
             PanCamPlugin,
             bevy_lospec::PalettePlugin,
         ))
+        .init_state::<GameState>()
+        .insert_resource(Msaa::Off)
+        .add_loading_state(
+            LoadingState::new(GameState::Loading)
+                .continue_to_state(GameState::Running)
+                .load_collection::<AssetHandles>(),
+        )
         .add_systems(OnEnter(GameState::Running), setup)
         .run();
 }
@@ -100,7 +101,7 @@ fn setup(
                 .filter(|c| *c != &clear_color)
                 .choose(&mut rng)
                 .copied()
-                .unwrap_or(Color::PINK);
+                .unwrap_or(css::PINK.into());
 
             let index = i + j * w;
 

--- a/examples/oscilloscope.rs
+++ b/examples/oscilloscope.rs
@@ -1,0 +1,59 @@
+use bevy::color::palettes::css;
+use bevy::prelude::*;
+use bevy_pancam::*;
+use bevy_smud::{prelude::*, SIMPLE_FILL_HANDLE};
+
+fn main() {
+    App::new()
+        // bevy_smud comes with anti-aliasing built into the standards fills
+        // which is more efficient than MSAA, and also works on Linux, wayland
+        .insert_resource(Msaa::Off)
+        .insert_resource(ClearColor(Color::BLACK))
+        .add_plugins((DefaultPlugins, SmudPlugin, PanCamPlugin))
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut shaders: ResMut<Assets<Shader>>,
+) {
+    // The fill takes a distance and a color and returns another color
+    commands.spawn(ShapeBundle {
+        shape: SmudShape {
+            color: css::GREEN.into(),
+            sdf: asset_server.load("bevy.wgsl"),
+            fill: shaders.add_fill_body(
+                r"
+var col = color.rgb / sqrt(abs(d));
+// col *= smoothstep(1.5, 0.5, length(p)); // We don't have p. This would give a vignette.
+
+// This is a brighter effect.
+return vec4<f32>(col, color.a);
+// This is a darker effect.
+// return vec4<f32>(aces_approx(col), color.a);
+}
+
+// HACK: We're gonna cheat on this template and add some auxiliary functions.
+
+// License: Unknown, author: Matt Taylor (https://github.com/64), found: https://64.github.io/tonemapping/
+fn aces_approx(v_: vec3<f32>) -> vec3<f32> {
+    var v = max(v_, vec3<f32>(0.0));
+    v *= 0.6;
+    let a: f32 = 2.51;
+    let b: f32 = 0.03;
+    let c: f32 = 2.43;
+    let d: f32 = 0.59;
+    let e: f32 = 0.14;
+    return saturate((v * (a * v + b)) / (v * (c * v + d) + e));
+",
+            ),
+
+            frame: Frame::Quad(295.),
+        },
+        ..default()
+    });
+
+    commands.spawn((Camera2dBundle::default(), PanCam::default()));
+}

--- a/examples/oscilloscope.rs
+++ b/examples/oscilloscope.rs
@@ -22,7 +22,8 @@ fn setup(
     // The fill takes a distance and a color and returns another color
     commands.spawn(ShapeBundle {
         shape: SmudShape {
-            color: css::GREEN.into(),
+            // color: css::GREEN.into(),
+            color: css::ORANGE.into(),
             sdf: asset_server.load("bevy.wgsl"),
             fill: shaders.add_fill_body(
                 r"
@@ -35,7 +36,7 @@ return vec4<f32>(col, color.a);
 // return vec4<f32>(aces_approx(col), color.a);
 }
 
-// HACK: We're gonna cheat on this template and add some auxiliary functions.
+// HACK: We're gonna cheat on this template and add an auxiliary function.
 
 // License: Unknown, author: Matt Taylor (https://github.com/64), found: https://64.github.io/tonemapping/
 fn aces_approx(v_: vec3<f32>) -> vec3<f32> {

--- a/examples/sorting.rs
+++ b/examples/sorting.rs
@@ -7,7 +7,7 @@ fn main() {
         // bevy_smud comes with anti-aliasing built into the standards fills
         // which is more efficient than MSAA, and also works on Linux, wayland
         .insert_resource(Msaa::Off)
-        .insert_resource(ClearColor(Color::rgb(0.7, 0.8, 0.7)))
+        .insert_resource(ClearColor(Color::srgb(0.7, 0.8, 0.7)))
         .add_plugins((DefaultPlugins, SmudPlugin, PanCamPlugin))
         .add_systems(Startup, setup)
         .run();
@@ -18,7 +18,7 @@ fn setup(mut commands: Commands, mut shaders: ResMut<Assets<Shader>>) {
     commands.spawn(ShapeBundle {
         transform: Transform::from_translation(Vec3::Z * 3.),
         shape: SmudShape {
-            color: Color::rgb(0.0, 0.0, 0.0),
+            color: Color::srgb(0.0, 0.0, 0.0),
             sdf: shaders.add_sdf_body("return smud::sd_circle(p, 70.);"),
             frame: Frame::Quad(80.),
             ..default()
@@ -30,7 +30,7 @@ fn setup(mut commands: Commands, mut shaders: ResMut<Assets<Shader>>) {
     commands.spawn(ShapeBundle {
         transform: Transform::from_translation(Vec3::Z * 2.),
         shape: SmudShape {
-            color: Color::rgb(0.46, 0.42, 0.80),
+            color: Color::srgb(0.46, 0.42, 0.80),
             sdf: shaders.add_sdf_body("return smud::sd_circle(p, 150.);"),
             frame: Frame::Quad(200.),
             ..default()
@@ -42,7 +42,7 @@ fn setup(mut commands: Commands, mut shaders: ResMut<Assets<Shader>>) {
     commands.spawn(ShapeBundle {
         transform: Transform::from_translation(Vec3::Z * 1.),
         shape: SmudShape {
-            color: Color::rgb(0.83, 0.82, 0.80),
+            color: Color::srgb(0.83, 0.82, 0.80),
             sdf: shaders.add_sdf_body("return smud::sd_vesica(p.yx, 400., 150.);"),
             frame: Frame::Quad(400.),
             ..default()

--- a/examples/time.rs
+++ b/examples/time.rs
@@ -7,7 +7,7 @@ fn main() {
         // bevy_smud comes with anti-aliasing built into the standards fills
         // which is more efficient than MSAA, and also works on Linux, wayland
         .insert_resource(Msaa::Off)
-        .insert_resource(ClearColor(Color::rgb(0.7, 0.8, 0.7)))
+        .insert_resource(ClearColor(Color::srgb(0.7, 0.8, 0.7)))
         .add_plugins((DefaultPlugins, SmudPlugin, PanCamPlugin))
         .add_systems(Startup, setup)
         .run();
@@ -18,7 +18,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     commands.spawn(ShapeBundle {
         shape: SmudShape {
-            color: Color::rgb(0.36, 0.41, 0.45),
+            color: Color::srgb(0.36, 0.41, 0.45),
             sdf: bevy_shape_shader,
             frame: Frame::Quad(400.),
             ..default()

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -9,7 +9,7 @@ fn main() {
         // bevy_smud comes with anti-aliasing built into the standards fills
         // which is more efficient than MSAA, and also works on Linux, wayland
         .insert_resource(Msaa::Off)
-        .insert_resource(ClearColor(Color::rgb(0.7, 0.8, 0.7)))
+        .insert_resource(ClearColor(Color::srgb(0.7, 0.8, 0.7)))
         .add_plugins((DefaultPlugins, SmudPlugin, PanCamPlugin))
         .add_systems(Startup, setup)
         .run();
@@ -25,7 +25,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     };
 
     let shape = SmudShape {
-        color: Color::rgb(0.36, 0.41, 0.45),
+        color: Color::srgb(0.36, 0.41, 0.45),
         sdf: bevy_shape_shader,
         frame: Frame::Quad(295.),
         ..default()

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use bevy::color::palettes::css;
 
 use crate::DEFAULT_FILL_HANDLE;
 
@@ -23,7 +24,7 @@ pub struct SmudShape {
 impl Default for SmudShape {
     fn default() -> Self {
         Self {
-            color: Color::PINK,
+            color: css::PINK.into(),
             sdf: default(),
             frame: default(),
             fill: DEFAULT_FILL_HANDLE,

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,5 +1,5 @@
-use bevy::prelude::*;
 use bevy::color::palettes::css;
+use bevy::prelude::*;
 
 use crate::DEFAULT_FILL_HANDLE;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,27 +19,27 @@ use bevy::{
     render::{
         globals::{GlobalsBuffer, GlobalsUniform},
         render_phase::{
-            AddRenderCommand, DrawFunctions, PhaseItem, RenderCommand, RenderCommandResult,
-            SetItemPipeline, TrackedRenderPass, ViewSortedRenderPhases, PhaseItemExtraIndex,
+            AddRenderCommand, DrawFunctions, PhaseItem, PhaseItemExtraIndex, RenderCommand,
+            RenderCommandResult, SetItemPipeline, TrackedRenderPass, ViewSortedRenderPhases,
         },
         render_resource::{
             BindGroup, BindGroupEntries, BindGroupLayout, BindGroupLayoutEntry, BindingType,
-            BlendState, BufferBindingType, BufferUsages, RawBufferVec, CachedRenderPipelineId,
-            ColorTargetState, ColorWrites, Face, FragmentState, FrontFace, MultisampleState,
-            PipelineCache, PolygonMode, PrimitiveState, PrimitiveTopology,
-            RenderPipelineDescriptor, ShaderImport, ShaderStages, ShaderType,
-            SpecializedRenderPipeline, SpecializedRenderPipelines, TextureFormat, VertexAttribute,
-            VertexBufferLayout, VertexFormat, VertexState, VertexStepMode,
+            BlendState, BufferBindingType, BufferUsages, CachedRenderPipelineId, ColorTargetState,
+            ColorWrites, Face, FragmentState, FrontFace, MultisampleState, PipelineCache,
+            PolygonMode, PrimitiveState, PrimitiveTopology, RawBufferVec, RenderPipelineDescriptor,
+            ShaderImport, ShaderStages, ShaderType, SpecializedRenderPipeline,
+            SpecializedRenderPipelines, TextureFormat, VertexAttribute, VertexBufferLayout,
+            VertexFormat, VertexState, VertexStepMode,
         },
         renderer::{RenderDevice, RenderQueue},
         texture::BevyDefault,
         view::{
-            ExtractedView, ViewTarget, ViewUniform, ViewUniformOffset, ViewUniforms,
-            VisibleEntities, WithMesh, check_visibility, VisibilitySystems,
+            check_visibility, ExtractedView, ViewTarget, ViewUniform, ViewUniformOffset,
+            ViewUniforms, VisibilitySystems, VisibleEntities, WithMesh,
         },
         Extract, MainWorld, Render, RenderApp, RenderSet,
     },
-    utils::{HashMap},
+    utils::HashMap,
 };
 use bytemuck::{Pod, Zeroable};
 use fixedbitset::FixedBitSet;
@@ -85,19 +85,16 @@ pub struct SmudPlugin;
 impl Plugin for SmudPlugin {
     fn build(&self, app: &mut App) {
         // All the messy boiler-plate for loading a bunch of shaders
-        app.add_plugins(ShaderLoadingPlugin)
-           .add_systems(
-                PostUpdate,
-                check_visibility::<With<SmudShape>>
-                    .in_set(VisibilitySystems::CheckVisibility)
-            );
+        app.add_plugins(ShaderLoadingPlugin).add_systems(
+            PostUpdate,
+            check_visibility::<With<SmudShape>>.in_set(VisibilitySystems::CheckVisibility),
+        );
         // app.add_plugins(UiShapePlugin);
 
         app.register_type::<SmudShape>();
     }
 
     fn finish(&self, app: &mut App) {
-
         let render_app = app.sub_app_mut(RenderApp);
         render_app
             .add_render_command::<Transparent2d, DrawSmudShape>()
@@ -512,7 +509,11 @@ fn queue_shapes(
             | PipelineKey::from_primitive_topology(PrimitiveTopology::TriangleStrip);
 
         view_entities.clear();
-        view_entities.extend(visible_entities.iter::<WithMesh>().map(|e| e.index() as usize));
+        view_entities.extend(
+            visible_entities
+                .iter::<WithMesh>()
+                .map(|e| e.index() as usize),
+        );
 
         transparent_phase
             .items

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use bevy::utils::Uuid;
+use uuid::Uuid;
 
 pub fn generate_shader_id() -> String {
     Uuid::new_v4().to_string().replace('-', "_")


### PR DESCRIPTION
I updated to bevy 0.14 based off @danielmelody's fork that updated to bevy 0.13. I bumped the version number of 0.7 to 0.9 in case you wanted to publish a version 0.8 to support bevy 0.13.

In addition, I added an oscilloscope example. It's just a cool effect I wanted to see in action for a jam game.